### PR TITLE
Replace Jekyll SEO tags with handcrafted set

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,70 +4,24 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    {% if seo_tag.title? %}
-      <title>{{ seo_tag.title }}</title>
-    {% endif %}
-
-    {% if seo_tag.author.name %}
-      <meta name="author" content="{{ seo_tag.author.name }}" />
-    {% endif %}
-
-    {% if seo_tag.description %}
-      <meta name="description" content="{{ seo_tag.description }}" />
-    {% endif %}
-
-    {% if site.url %}
-      <link rel="canonical" href="{{ seo_tag.canonical_url }}" />
-    {% endif %}
-
-    {% if paginator.previous_page %}
-      <link rel="prev" href="{{ paginator.previous_page_path | absolute_url }}" />
-    {% endif %}
-
-    {% if paginator.next_page %}
-      <link rel="next" href="{{ paginator.next_page_path | absolute_url }}" />
-    {% endif %}
-
-    {% if seo_tag.image %}
-      <meta name="twitter:card" content="{{ page.twitter.card | default: site.twitter.card | default: "summary_large_image" }}" />  
-    {% else %}
-      <meta name="twitter:card" content="summary" />
-    {% endif %}
-
-    {% if site.twitter %}
-      <meta name="twitter:site" content="@{{ site.twitter.username | remove:'@' }}" />
-
-      {% if seo_tag.author.twitter %}
-        <meta name="twitter:creator" content="@{{ seo_tag.author.twitter | remove:'@' }}" />
-      {% endif %}
-    {% endif %}
-
-    {% if site.webmaster_verifications %}
-      {% if site.webmaster_verifications.google %}
-        <meta name="google-site-verification" content="{{ site.webmaster_verifications.google }}" />
-      {% endif %}
-
-      {% if site.webmaster_verifications.bing %}
-        <meta name="msvalidate.01" content="{{ site.webmaster_verifications.bing }}" />
-      {% endif %}
-
-      {% if site.webmaster_verifications.alexa %}
-        <meta name="alexaVerifyID" content="{{ site.webmaster_verifications.alexa }}" />
-      {% endif %}
-
-      {% if site.webmaster_verifications.yandex %}
-        <meta name="yandex-verification" content="{{ site.webmaster_verifications.yandex }}" />
-      {% endif %}
-
-      {% if site.webmaster_verifications.baidu %}
-        <meta name="baidu-site-verification" content="{{ site.webmaster_verifications.baidu }}" />
-      {% endif %}
-    {% elsif site.google_site_verification %}
-      <meta name="google-site-verification" content="{{ site.google_site_verification }}" />
-    {% endif %}
-
+    
+    <title>{{ page.title }}</title>
+    <link rel="canonical" href="{{ page.url | absolute_url }}" />
+    <meta name="description" content="{{ page.excerpt }}" />
+    
+    <meta name="author" content="Matt Borja" />
     <script type="application/ld+json">
-      {{ seo_tag.json_ld | jsonify }}
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "author": {
+        "@type": "Person",
+        "name": "Matt Borja",
+        "url": "https://mattborja.dev/"
+      },
+      "headline": "{{ page.title }}",
+      "url": "{{ page.url | absolute_url }}"
+    }
     </script>
     
     <link href="https://mattborja.dev/assets/css/bootstrap-5.2.0-beta1.min.css" rel="stylesheet" />


### PR DESCRIPTION
Jekyll SEO tags introduces attributes that cause XHTML 1.0 Strict validation to fail (i.e. `property`) and have been replaced here with a handcrafted set that should be valid for this DOCTYPE.

Signed-off-by: Matt Borja <3855027+mattborja@users.noreply.github.com>